### PR TITLE
Restore em dash in epigraph citation

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -164,7 +164,7 @@ q{
 }
 
 #epigraph-2 p{
-	text-indent: 0;
+	text-indent: 1em;
 }
 
 #chapter-13 blockquote,

--- a/src/epub/text/epigraph-1.xhtml
+++ b/src/epub/text/epigraph-1.xhtml
@@ -9,7 +9,7 @@
 		<section id="epigraph-1" epub:type="epigraph">
 			<blockquote>
 				<p>“At one time the earth was probably a white-hot sphere like the sun.”</p>
-				<cite>Tarr and McMurry</cite>
+				<cite>—Tarr and McMurry</cite>
 			</blockquote>
 		</section>
 	</body>


### PR DESCRIPTION
* As this epigraph is not in a header, the `<cite>` should have a leading em-dash
* Add (back) indentation to the epigraph